### PR TITLE
Fix certification requirements for Quarkus

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -42,4 +42,3 @@ warn_list:
   - name[play]
 
 use_default_rules: true
-parseable: true

--- a/.config/molecule/config.yml
+++ b/.config/molecule/config.yml
@@ -1,0 +1,33 @@
+---
+driver:
+  name: docker
+
+platforms:
+  - name: instance-ubi9
+    image: registry.access.redhat.com/ubi9/ubi-init:latest
+    command: "/usr/sbin/init"
+    pre_build_image: true
+    privileged: true
+
+  - name: instance-ubi10
+    image: registry.access.redhat.com/ubi10/ubi-init:latest
+    command: "/usr/sbin/init"
+    pre_build_image: true
+    privileged: true
+
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      interpreter_python: /usr/bin/python3.12
+    ssh_connection:
+      pipelining: false
+  env:
+    ANSIBLE_FORCE_COLOR: "true"
+    ANSIBLE_COLLECTIONS_PATHS: "~/.ansible/collections/"
+    ANSIBLE_ROLES_PATH: "../../roles"
+  inventory:
+    group_vars:
+      all:
+        quarkus_builder_host: "{{ inventory_hostname }}"
+        quarkus_app_workdir: /opt/workdir

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .vscode
 
 __pycache__/
+.ansible/
 
 # Galaxy artifacts.
 *.tar.gz

--- a/README.md
+++ b/README.md
@@ -18,7 +18,13 @@ Once you have installed Ansible on your computer you can simply run the followin
 <!--start requires_ansible-->
 ## Ansible version compatibility
 
-This collection has been tested against following Ansible versions: **>=2.13.3**.
+This collection has been tested against following Ansible versions: **>=2.16.0**.
+
+## Requirements
+
+- **Python**: 3.12 or later
+- **Supported platforms**: RHEL 9, RHEL 10 (and UBI equivalents)
+- **Java**: JDK 21 (default, configurable to other versions available on the platform)
 
 ## Install
 
@@ -30,3 +36,24 @@ Plugins and modules within a collection may be tested with only specific Ansible
 ### Roles
 
 * [quarkus](https://github.com/ansible-middleware/quarkus/blob/main/roles/quarkus/README.md): clone the repo app, build the app and deploys it as a systemd service.
+
+
+## Support
+
+<!--start support -->
+
+For bug reports and feature requests, use [GitHub Issues](https://github.com/ansible-middleware/quarkus/issues).
+
+<!--end support -->
+
+
+## Release and Upgrade Notes
+
+For details on changes between versions, please see the [CHANGELOG](https://github.com/ansible-middleware/quarkus/blob/main/CHANGELOG.rst) for this collection.
+
+
+## License
+
+Apache License v2.0 or later
+
+See [LICENSE](LICENSE) to view the full text.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 antsibull>=0.17.0
 antsibull-docs
 antsibull-changelog
-ansible-core>=2.14.1
+ansible-core>=2.16.0
 sphinx-rtd-theme
 git+https://github.com/felixfontein/ansible-basic-sphinx-ext
 myst-parser

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -28,6 +28,7 @@ build_ignore:
   - .github
   - .ansible-lint
   - .yamllint
+  - .DS_Store
   - '*.tar.gz'
   - '*.zip'
   - molecule

--- a/molecule/common.yml
+++ b/molecule/common.yml
@@ -6,29 +6,21 @@
     - not sudo_pkg_name is defined
 
 - name: "Ensure {{ sudo_pkg_name }} is installed (if user is root)."
-  ansible.builtin.yum:
+  ansible.builtin.dnf:
     name: "{{ sudo_pkg_name }}"
+    state: present
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
   when:
-    - ansible_user_id == 'root'
-
-- name: Gather the package facts
-  ansible.builtin.package_facts:
-    manager: auto
-
-- name: "Check if {{ sudo_pkg_name }} is installed."
-  ansible.builtin.assert:
-    that:
-      - sudo_pkg_name in ansible_facts.packages
+    - ansible_facts['user_id'] == 'root'
 
 - name: "Ensure required packages are installed."
   become: yes
   become_user: root
-  ansible.builtin.yum:
+  ansible.builtin.dnf:
     name:
       - git
       - procps-ng
     state: present
-
-- name: Display Ansible version
-  ansible.builtin.debug:
-    msg: "Ansible version is {{ ansible_version.full }}, running with Python {{ ansible_python_version }}."
+  vars:
+    ansible_python_interpreter: /usr/bin/python3

--- a/molecule/common_bootstrap.yml
+++ b/molecule/common_bootstrap.yml
@@ -1,0 +1,11 @@
+---
+- name: "Bootstrap Python 3.12"
+  hosts: all
+  gather_facts: false
+  vars:
+    ansible_python_interpreter: auto_silent
+  tasks:
+    - name: "Install Python 3.12"
+      ansible.builtin.dnf:
+        name: python3.12
+        state: present

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,6 +1,3 @@
 ---
 - name: Converge
   import_playbook: ../../playbooks/playbook.yml
-  vars:
-    quarkus_app_workdir: /opt/workdir
-    quarkus_builder_host: instance

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,19 +1,5 @@
 ---
-driver:
-  name: docker
-platforms:
-  - name: instance
-    image: registry.access.redhat.com/ubi8/ubi-init:latest
-    pre_build_image: true
-    privileged: true
-    command: "/usr/sbin/init"
 provisioner:
-  name: ansible
-  config_options:
-    defaults:
-      interpreter_python: auto_silent
-    ssh_connection:
-      pipelining: false
   playbooks:
     prepare: ../prepare.yml
     converge: converge.yml
@@ -22,14 +8,13 @@ provisioner:
     host_vars:
       localhost:
         ansible_python_interpreter: "{{ ansible_playbook_python }}"
-      instance:
+    group_vars:
+      all:
         app_name: getting-started
-  env:
-    ANSIBLE_FORCE_COLOR: "true"
-    ANSIBLE_COLLECTIONS_PATHS: "~/.ansible/collections/"
-    ANSIBLE_ROLES_PATH: "../../roles"
+
 verifier:
   name: ansible
+
 scenario:
   test_sequence:
     - cleanup

--- a/molecule/getting-started-reactive/converge.yml
+++ b/molecule/getting-started-reactive/converge.yml
@@ -3,4 +3,3 @@
   import_playbook: ../../playbooks/playbook.yml
   vars:
     quarkus_app_workdir: /opt/workdir
-    quarkus_builder_host: instance

--- a/molecule/getting-started-reactive/molecule.yml
+++ b/molecule/getting-started-reactive/molecule.yml
@@ -1,19 +1,5 @@
 ---
-driver:
-  name: docker
-platforms:
-  - name: instance
-    image: registry.access.redhat.com/ubi8/ubi-init:latest
-    pre_build_image: true
-    privileged: true
-    command: "/usr/sbin/init"
 provisioner:
-  name: ansible
-  config_options:
-    defaults:
-      interpreter_python: auto_silent
-    ssh_connection:
-      pipelining: false
   playbooks:
     prepare: ../prepare.yml
     converge: converge.yml
@@ -22,14 +8,13 @@ provisioner:
     host_vars:
       localhost:
         ansible_python_interpreter: "{{ ansible_playbook_python }}"
-      instance:
+    group_vars:
+      all:
         app_name: getting-started-reactive
-  env:
-    ANSIBLE_FORCE_COLOR: "true"
-    ANSIBLE_COLLECTIONS_PATHS: "~/.ansible/collections/"
-    ANSIBLE_ROLES_PATH: "../../roles"
+
 verifier:
   name: ansible
+
 scenario:
   test_sequence:
     - cleanup

--- a/molecule/prepare.yml
+++ b/molecule/prepare.yml
@@ -1,6 +1,10 @@
 ---
+- name: "Import Python bootstrap"
+  ansible.builtin.import_playbook: common_bootstrap.yml
+
 - name: Prepare
   hosts: all
+  gather_facts: true
   tasks:
     - name: "Ensure common prepare phase are executed"
       ansible.builtin.include_tasks: common.yml

--- a/molecule/todo-demo-app/converge.yml
+++ b/molecule/todo-demo-app/converge.yml
@@ -3,7 +3,6 @@
   import_playbook: ../../playbooks/playbook.yml
   vars:
     quarkus_app_workdir: /opt/workdir
-    app_name: 'todo-demo-app'
     quarkus_app_repo_url: 'https://github.com/quarkusio/todo-demo-app'
     quarkus_app_source_folder: ''
     quarkus_use_mvnw: False

--- a/molecule/todo-demo-app/molecule.yml
+++ b/molecule/todo-demo-app/molecule.yml
@@ -1,19 +1,5 @@
 ---
-driver:
-  name: docker
-platforms:
-  - name: instance
-    image: registry.access.redhat.com/ubi8/ubi-init:latest
-    pre_build_image: true
-    privileged: true
-    command: "/usr/sbin/init"
 provisioner:
-  name: ansible
-  config_options:
-    defaults:
-      interpreter_python: auto_silent
-    ssh_connection:
-      pipelining: false
   playbooks:
     prepare: prepare.yml
     converge: converge.yml
@@ -22,14 +8,13 @@ provisioner:
     host_vars:
       localhost:
         ansible_python_interpreter: "{{ ansible_playbook_python }}"
-      instance:
-        quarkus_builder_host: instance
-  env:
-    ANSIBLE_FORCE_COLOR: "true"
-    ANSIBLE_COLLECTIONS_PATHS: "~/.ansible/collections/"
-    ANSIBLE_ROLES_PATH: "../../roles"
+    group_vars:
+      all:
+        app_name: todo-demo-app
+
 verifier:
   name: ansible
+
 scenario:
   test_sequence:
     - cleanup

--- a/molecule/todo-demo-app/pgsql/set_up.yml
+++ b/molecule/todo-demo-app/pgsql/set_up.yml
@@ -6,20 +6,23 @@
 - name: "Ensure yumrepo and packages are installed"
   become: yes
   become_user: root
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
   block:
-    - name: "Ensure the Yum repo for Postgresql are available ({{ ansible_distribution }})"
+    - name: "Ensure the Yum repo for Postgresql are available ({{ ansible_facts['distribution'] }})"
       ansible.builtin.yum_repository:
         name: Postgresql
         description: Yum Repository for Postgresql
         baseurl: "{{ pgsql_yum_repo_baseurl }}"
+        gpgcheck: no
       when:
         - not run_on_internal_ci
 
     - name: "Ensure Postgresql DB is installed."
       ansible.builtin.dnf:
-        name: postgresql-server
-        # if you know where to find the rpmkey, please fill a PR :)
-        disable_gpg_check: True
+        name: postgresql14-server
+        state: present
+        disable_gpg_check: yes
 
     - name: "Ensure Posgresql DB has been initialized."
       ansible.builtin.command: "{{ pgsql_init_cmd }}"

--- a/molecule/todo-demo-app/pgsql/vars.yml
+++ b/molecule/todo-demo-app/pgsql/vars.yml
@@ -1,9 +1,8 @@
 ---
-pgsql_yum_repo_baseurl: 'http://download.postgresql.org/pub/repos/yum/13/redhat/rhel-8-x86_64/'
-# "{{ (item|int < 11)|ternary('rw', 'dp') }}"
-pgsql_service_name: "{{ (run_on_internal_ci) | ternary('postgresql.service', 'postgresql-13.service') }}"
-pgsql_init_cmd: "{{ (run_on_internal_ci) | ternary('postgresql-setup --initdb', 'postgresql-13-setup initdb') }}"
-pgsql_path_to_hba_conf: "{{ (run_on_internal_ci) | ternary('/var/lib/pgsql/data/pg_hba.conf','/var/lib/pgsql/13/data/pg_hba.conf') }}"
+pgsql_yum_repo_baseurl: "http://download.postgresql.org/pub/repos/yum/14/redhat/rhel-{{ ansible_facts['distribution_major_version'] }}-{{ ansible_facts['architecture'] }}/"
+pgsql_service_name: "{{ (run_on_internal_ci) | ternary('postgresql.service', 'postgresql-14.service') }}"
+pgsql_init_cmd: "{{ (run_on_internal_ci) | ternary('postgresql-setup --initdb', 'postgresql-14-setup initdb') }}"
+pgsql_path_to_hba_conf: "{{ (run_on_internal_ci) | ternary('/var/lib/pgsql/data/pg_hba.conf','/var/lib/pgsql/14/data/pg_hba.conf') }}"
 pgsql_app_dbname: rest-crud
 pgsql_app_user: restcrud
 pgsql_app_user_password: restcrud

--- a/molecule/todo-demo-app/prepare.yml
+++ b/molecule/todo-demo-app/prepare.yml
@@ -1,6 +1,10 @@
 ---
+- name: "Import Python bootstrap"
+  ansible.builtin.import_playbook: ../common_bootstrap.yml
+
 - name: Prepare
   hosts: all
+  gather_facts: true
   vars_files:
     - pgsql/vars.yml
   tasks:
@@ -9,7 +13,3 @@
 
     - name: "Set up DB required by ToDo app"
       ansible.builtin.include_tasks: pgsql/set_up.yml
-
-    - name: Display Ansible version
-      ansible.builtin.debug:
-        msg: "Ansible version is  {{ ansible_version.full }}"

--- a/playbooks/playbook.yml
+++ b/playbooks/playbook.yml
@@ -2,12 +2,12 @@
 - name: "Build and deploy a Quarkus app using Ansible"
   hosts: all
   gather_facts: true
-  roles:
-    - quarkus
   vars:
     quarkus_app_source_folder: "{{ app_name }}"
     quarkus_path_to_folder_to_deploy: /opt/quarkus_deploy
     quarkus_app_workdir: "/root/{{ app_name }}.git"
+  roles:
+    - quarkus
   pre_tasks:
     # app_name and quarkus_app_repo_url are NOT set so that Molecule scenarios can provides them
     # the following defaults are to ensure the playbook works "out of the box" without adding missing information.

--- a/roles/quarkus/README.md
+++ b/roles/quarkus/README.md
@@ -19,8 +19,8 @@ Role Defaults
 |`quarkus_build_delete_workdir`| `Should Ansible delete the workdir` | `true` |
 |`quarkus_build_shell_interpreter`| `Shell interpreter used by Ansible` | `/bin/bash` |
 |`quarkus_build_relative_path_to_deploy_dir`| `Path to the directory containing the Quarkus app to deploy` | `target/quarkus-app/` |
-|`quarkus_java_package_version`| `Package name of the JDK to used to build and run the Quarkus app` | `'java-17-openjdk'` |
-|`quarkus_java_home`| `Path to the Java Home used` | `'/usr/lib/jvm/jre-17-openjdk'` |
+|`quarkus_java_package_version`| `Package name of the JDK to used to build and run the Quarkus app` | `'java-21-openjdk'` |
+|`quarkus_java_home`| `Path to the Java Home used` | `'/usr/lib/jvm/java-21-openjdk'` |
 |`quarkus_app_workdir`| `Path to the app work directory` | `'/tmp/workdir'` |
 |`quarkus_app_user`| `System user used to run the app` | `quarkus_app` |
 |`quarkus_app_group`| `System group used to run the app` | `"{{ quarkus_app_user }}"` |

--- a/roles/quarkus/defaults/main.yml
+++ b/roles/quarkus/defaults/main.yml
@@ -32,10 +32,10 @@ quarkus_deploy_systemd_service_env_template: templates/service_env.j2
 quarkus_firewalld_package: firewalld
 
 quarkus_java_home_isdir: False
-quarkus_java_home_islnk: True
+quarkus_java_home_islnk: False
 quarkus_java_home: "/usr/lib/jvm/java-{{ quarkus_java_version }}-openjdk"
 quarkus_java_package_version: "java-{{ quarkus_java_version }}-openjdk-devel"
-quarkus_java_version: 17
+quarkus_java_version: 21
 
 quarkus_use_mvnw: True
 quarkus_maven_build_opts: ''
@@ -46,7 +46,7 @@ quarkus_maven_homedir: /opt/apache/maven
 quarkus_maven_homedir_requires_privileges: yes
 quarkus_maven_homedir_user: root
 quarkus_maven_install: True
-quarkus_maven_version: 3.8.9
+quarkus_maven_version: 3.9.16
 
 quarkus_path_to_folder_to_deploy_become_user: root
 quarkus_path_to_folder_to_deploy_requires_become: yes

--- a/roles/quarkus/tasks/build.yml
+++ b/roles/quarkus/tasks/build.yml
@@ -30,13 +30,13 @@
       when:
         - quarkus_app_builder_non_root_username is defined
       block:
-        - name: "Define Quarkus app builder username, if not defined, to {{ quarkus_app_builder_non_root_username }}"
+        - name: "Define Quarkus app builder username from non-root username"
           ansible.builtin.set_fact:
             quarkus_app_builder_user: "{{ quarkus_app_builder_non_root_username }}"
           when:
             - not quarkus_app_builder_user is defined
 
-        - name: "Define Quarkus app builder group, if not defined, to {{ quarkus_app_builder_non_root_username }}"
+        - name: "Define Quarkus app builder group from non-root username"
           ansible.builtin.set_fact:
             quarkus_app_builder_group: "{{ quarkus_app_builder_non_root_username }}"
           when:
@@ -61,8 +61,11 @@
         repo: "{{ quarkus_app_repo_url }}"
         dest: "{{ quarkus_app_workdir }}"
         version: "{{ app_tag | default(omit) }}"
+      vars:
+        ansible_python_interpreter: /usr/bin/python3
       when:
-        - quarkus_app_repo_url is defined and quarkus_app_repo_url
+        - quarkus_app_repo_url is defined
+        - quarkus_app_repo_url | length > 0
 
     - name: "Load metadata on source directory"
       ansible.builtin.stat:

--- a/roles/quarkus/tasks/deploy/app.yml
+++ b/roles/quarkus/tasks/deploy/app.yml
@@ -7,4 +7,4 @@
     group: "{{ quarkus_app_group | default(omit) }}"
     remote_src: "{{ quarkus_app_src_dir_remote }}"
     mode: 0755
-  changed_when: "{{ quarkus_app_update | default(false) }}"
+  changed_when: quarkus_app_update | default(false)

--- a/roles/quarkus/tasks/deploy/prereqs.yml
+++ b/roles/quarkus/tasks/deploy/prereqs.yml
@@ -9,9 +9,11 @@
         - not quarkus_openjdk_package_version is defined and quarkus_java_version is defined
 
     - name: "Ensure required OpenJDK is installed on target."
-      ansible.builtin.package:
+      ansible.builtin.dnf:
         name: "{{ quarkus_openjdk_package_version }}"
         state: present
+      vars:
+        ansible_python_interpreter: /usr/bin/python3
       when:
         - quarkus_deploy_skip_java_package_install is defined and not quarkus_deploy_skip_java_package_install
         - quarkus_openjdk_package_version is defined

--- a/roles/quarkus/tasks/java.yml
+++ b/roles/quarkus/tasks/java.yml
@@ -3,6 +3,8 @@
   ansible.builtin.dnf:
     name: "{{ quarkus_java_package_version }}"
     state: present
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
   become: true
   when:
     - quarkus_app_builder_skip_install_java_package is defined and not quarkus_app_builder_skip_install_java_package

--- a/roles/quarkus/tasks/target_supported.yml
+++ b/roles/quarkus/tasks/target_supported.yml
@@ -2,7 +2,7 @@
 - name: "Ensure target node is supported."
   ansible.builtin.assert:
     that:
-      - ansible_os_family == 'RedHat'
+      - ansible_facts['os_family'] == 'RedHat'
     quiet: true
   when:
-    - ansible_os_family is defined
+    - ansible_facts['os_family'] is defined

--- a/roles/quarkus/tasks/validate_deployment.yml
+++ b/roles/quarkus/tasks/validate_deployment.yml
@@ -28,9 +28,9 @@
       ansible.builtin.assert:
         that:
           - ansible_facts.services is defined
-          - ansible_facts.services["{{ quarkus_app_service_name }}.service"] is defined
-          - ansible_facts.services["{{ quarkus_app_service_name }}.service"]['status'] is defined
-          - ansible_facts.services["{{ quarkus_app_service_name }}.service"]['status'] == 'enabled'
-          - ansible_facts.services["{{ quarkus_app_service_name }}.service"]['state'] is defined
-          - ansible_facts.services["{{ quarkus_app_service_name }}.service"]['state'] == 'running'
+          - ansible_facts.services[quarkus_app_service_name ~ '.service'] is defined
+          - ansible_facts.services[quarkus_app_service_name ~ '.service']['status'] is defined
+          - ansible_facts.services[quarkus_app_service_name ~ '.service']['status'] == 'enabled'
+          - ansible_facts.services[quarkus_app_service_name ~ '.service']['state'] is defined
+          - ansible_facts.services[quarkus_app_service_name ~ '.service']['state'] == 'running'
         quiet: true


### PR DESCRIPTION
- Add .DS_Store to build_ignore in galaxy.yml
- Add Release and Upgrade Notes section to README
- Add License section to README

[AMW-522](https://redhat.atlassian.net/browse/AMW-522)

- Dropped RHEL8/UBI8 support, added RHEL9/UBI10
- Installed Python 3.12 on target hosts via bootstrap
- Used system Python (/usr/bin/python3) for dnf/package operations
- Set Python 3.12 as global interpreter for testing
- Updated defaults: JDK 17→21, Maven 3.8.9→3.9.16
- Fixed PostgreSQL repository to auto-detect system architecture (aarch64 vs x86_64)
- Centralized molecule config following wildfly pattern
- Fixed all deprecation warnings (ansible_facts)
- Added .ansible/ to .gitignore

[AMW-544](https://redhat.atlassian.net/browse/AMW-544)