### PR TITLE
Standardize .ansible-lint configuration

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,4 +1,6 @@
 # .ansible-lint
+profile: production
+
 exclude_paths:
   - .cache/
   - .github/

--- a/README.md
+++ b/README.md
@@ -56,4 +56,4 @@ For details on changes between versions, please see the [CHANGELOG](https://gith
 
 Apache License v2.0 or later
 
-See [LICENSE](LICENSE) to view the full text.
+See [LICENSE](https://github.com/ansible-middleware/quarkus/blob/main/LICENSE) to view the full text.


### PR DESCRIPTION
- Add profile: production to .ansible-lint for production-level linting