### PR TITLE
Set license key in galaxy.yml for Automation Hub

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -6,7 +6,7 @@ readme: README.md
 authors:
   - Romain Pelisse <rpelisse@redhat.com>
 description: Build and deploy a Quarkus based app from the Git repository URL
-license_file: "LICENSE"
+license: ["Apache-2.0"]
 tags:
   - quarkus
   - redhat


### PR DESCRIPTION
## Summary

Set `license: ["Apache-2.0"]` in galaxy.yml (replacing `license_file: "LICENSE"`) so the license surfaces properly in the Automation Hub UI.

Identified during Automation Hub certification review of `redhat.quarkus` v1.0.4.