### PR TITLE
Remove changelogs/fragments dotfile breaking sanity tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ docs/_build/
 
 inventory
 changelogs/.plugin-cache.yaml
+changelogs/fragments/*.yml
+changelogs/fragments/*.yaml

--- a/changelogs/fragments/.gitignore
+++ b/changelogs/fragments/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
Delete changelogs/fragments/.gitignore dotfile that causes ansible sanity test failure and add fragment patterns to root .gitignore.

[AMW-605](https://redhat.atlassian.net/browse/AMW-605)